### PR TITLE
some docs improvements and a workaround

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -20,13 +20,18 @@ This directory contains Kubernetes manifests for deploying gptme.
 
 ## Local Development
 
+Pre-requisites:
+
+```bash
+# macOS
+brew install skaffold kubectl minikube helm k9s
+```
+
 To run gptme locally with Kubernetes:
 
 1. Make sure you have a Kubernetes cluster running (minikube, kind, k3d, etc.)
 2. Create a `.env` file in the repository root with your API key:
-
-```
-   ```
+   ```bash
    ANTHROPIC_API_KEY=your_api_key_here
    ```
 

--- a/k8s/local/common/skaffold.helm.yaml
+++ b/k8s/local/common/skaffold.helm.yaml
@@ -9,6 +9,7 @@ manifests:
         remoteChart: ingress-nginx
         repo: https://kubernetes.github.io/ingress-nginx
         namespace: gptmingdom
+        version: "4.7.1"  # Use a version compatible with Kubernetes >= v1.20.0
         #createNamespace: false
         #recreatePods: false
         #skipBuildDependencies: false


### PR DESCRIPTION
We should maybe create a new private repo for the whole k8s folder.

We can still include the gptme source as a submodule for easy access to Dockerfile's etc.